### PR TITLE
Adopt rustmagazine.org domain and rename repo to rustmagazine

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A publication dedicated to the Rust programming language.
 
+https://rustmagazine.org
+
 ## Call for editors
 
 See [#4](https://github.com/RustMagazine/rustmagazine.github.io/issues/4).
@@ -12,4 +14,4 @@ See [#5](https://github.com/RustMagazine/rustmagazine.github.io/issues/5).
 
 ## Contribute to magazine
 
-https://rustmagazine.github.io/contribution/
+https://rustmagazine.org/contribution/

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ https://rustmagazine.org
 
 ## Call for editors
 
-See [#4](https://github.com/RustMagazine/rustmagazine.github.io/issues/4).
+See [#4](https://github.com/RustMagazine/rustmagazine/issues/4).
 
 ## Call for articles
 
-See [#5](https://github.com/RustMagazine/rustmagazine.github.io/issues/5).
+See [#5](https://github.com/RustMagazine/rustmagazine/issues/5).
 
 ## Contribute to magazine
 

--- a/pages/contribution.md
+++ b/pages/contribution.md
@@ -9,7 +9,7 @@ cargo install zine
 ## Clone the magazine
 
 ```
-$ git clone https://github.com/rustmagazine/rustmagazine.github.io
+$ git clone https://github.com/rustmagazine/rustmagazine
 
 $ cd rustmagazine
 

--- a/templates/article-extend.html
+++ b/templates/article-extend.html
@@ -3,7 +3,7 @@
 </div>
 <script
   src="https://giscus.app/client.js"
-  data-repo="rustmagazine/rustmagazine.github.io"
+  data-repo="rustmagazine/rustmagazine"
   data-repo-id="R_kgDOIcB-NQ"
   data-category="Articles"
   data-category-id="DIC_kwDOIcB-Nc4CSkor"

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -30,7 +30,7 @@
                 <div class="text-xl font-bold mb-4">More</div>
                 <a class="my-2 block hover:underline" href="/about">About</a>
                 <a class="my-2 block hover:underline" href="/contribution">How to contribute</a>
-                <a class="my-2 block hover:underline" href="https://github.com/RustMagazine/rustmagazine.github.io">Github</a>
+                <a class="my-2 block hover:underline" href="https://github.com/RustMagazine/rustmagazine">Github</a>
             </div>
         </div>
     </div>

--- a/zine.toml
+++ b/zine.toml
@@ -1,6 +1,6 @@
 
 [site]
-url = "https://rustmagazine.github.io"
+url = "https://rustmagazine.org"
 name = "Rust Magazine"
 description = "A publication dedicated to the Rust programming language."
 edit_url = "https://github.com/rustmagazine/rustmagazine.github.io/edit/main"

--- a/zine.toml
+++ b/zine.toml
@@ -3,10 +3,10 @@
 url = "https://rustmagazine.org"
 name = "Rust Magazine"
 description = "A publication dedicated to the Rust programming language."
-edit_url = "https://github.com/rustmagazine/rustmagazine.github.io/edit/main"
+edit_url = "https://github.com/rustmagazine/rustmagazine/edit/main"
 menu = [
     { name = "About", url = "/about" },
-    { name = "GitHub", url = "https://github.com/rustmagazine/rustmagazine.github.io" },
+    { name = "GitHub", url = "https://github.com/rustmagazine/rustmagazine" },
 ]
 social_image = "/static/bg.jpeg"
 


### PR DESCRIPTION
We now have an official custom domain: [rustmagazine.org](https://rustmagazine.org) 🎉🎉