### PR TITLE
Fix the capitalization of Github -> GitHub

### DIFF
--- a/content/issue-1/2022-review-the-adoption-of-rust-in-business-zh.md
+++ b/content/issue-1/2022-review-the-adoption-of-rust-in-business-zh.md
@@ -76,7 +76,7 @@ Warp 选择使用 Rust 语言来实现。使用 Rust 技术栈（包括 WebAssem
 
 ## 流媒体服务
 
-实时事件流媒体公司 InfinyOn 筹集了 500 万美元的种子资金，由 Gradient Ventures 和 Fly Ventures 领投，Bessemer Venture Partners、TSVC 等参投。InfinyOn 使用由 Rust 开发的动态数据可编程平台 [Fluvio](https://github.com/infinyon/fluvio) 。Fluvio 拥有超过 1,000 个 Github star，在开发人员和开源社区中越来越受欢迎。
+实时事件流媒体公司 InfinyOn 筹集了 500 万美元的种子资金，由 Gradient Ventures 和 Fly Ventures 领投，Bessemer Venture Partners、TSVC 等参投。InfinyOn 使用由 Rust 开发的动态数据可编程平台 [Fluvio](https://github.com/infinyon/fluvio) 。Fluvio 拥有超过 1,000 个 GitHub star，在开发人员和开源社区中越来越受欢迎。
 
 “在 Java 时代构建的遗留数据平台会生成大型二进制文件，需要大量内存，并且从边缘到核心的操作具有挑战性。这些也缺乏实时决策的在线处理能力，”InfinyOn 的联合创始人兼首席技术官 Sehyo Chang 说。“我们通过消除对 ETL 工具的需求来简化数据架构，提供更具成本效益的平台，内存减少高达 80 倍，并通过内存安全解决方案提供最大的安全性。”
 

--- a/content/issue-1/contribute-to-rustc.md
+++ b/content/issue-1/contribute-to-rustc.md
@@ -9,7 +9,7 @@ Here, I'd like to share my Rust experience with you.
 
 I have more than ten years of programming experience, the book [Essentials of Programming Languages](https://github.com/chenyukang/eopl) triggered my interests in programming languages and implementation.
 
-In 2014, I found Rust in Github, in that period of time, I was interested in OCaml, and Rust compiler was initially implemented in OCaml.
+In 2014, I found Rust in GitHub, in that period of time, I was interested in OCaml, and Rust compiler was initially implemented in OCaml.
 
 I spent some time to play with it, and then I begin to write some simple programs in Rust. I remember my first impression of Rust was that the language was too complex, with several kinds of pointers!
 

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -37,7 +37,7 @@
                 <div class="text-xl font-bold mb-4">More</div>
                 <a class="my-2 block hover:underline" href="/about">About</a>
                 <a class="my-2 block hover:underline" href="/contribution">How to contribute</a>
-                <a class="my-2 block hover:underline" href="https://github.com/RustMagazine/rustmagazine">Github</a>
+                <a class="my-2 block hover:underline" href="https://github.com/RustMagazine/rustmagazine">GitHub</a>
             </div>
         </div>
     </div>

--- a/zine.toml
+++ b/zine.toml
@@ -51,13 +51,13 @@ avatar = "/static/avatar/folyd.jpeg"
 bio = """
 The author of [Rust Search Extension](https://github.com/huhu/rust-search-extension) and [zine](https://github.com/zineland/zine).
 
-- [Github](https://github.com/folyd)
+- [GitHub](https://github.com/folyd)
 - [Blog](https://folyd.com)
 """
 
 [authors.yukang]
 bio = """
-- [Github](https://github.com/chenyukang)
+- [GitHub](https://github.com/chenyukang)
 - [Blog](https://catcoding.me)
 """
 


### PR DESCRIPTION
The platform is normally spelled GitHub, but it was spelled Github here. This small pull request fixes this problem.